### PR TITLE
build ordered resources

### DIFF
--- a/src/Webserver.API/Services/FileHandling/ApiDirectoryBuilder.cs
+++ b/src/Webserver.API/Services/FileHandling/ApiDirectoryBuilder.cs
@@ -180,7 +180,7 @@ namespace Siemens.Simatic.S7.Webserver.API.Services.FileHandling
                     }
                 }
             }
-            return resources;
+            return resources.OrderBy(el => el.Type).ThenBy(el => el.Size).ToList();
         }
     }
 }


### PR DESCRIPTION
the resources should be ordered when being built (so that a later comparison can be made with the same ordering)