### PR TITLE
chore: remove unused package reference

### DIFF
--- a/WebserverAPI.sln
+++ b/WebserverAPI.sln
@@ -3,15 +3,22 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32526.322
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{29F9C865-DCDE-477B-BD56-11451E6A6C1F}"
-	ProjectSection(SolutionItems) = preProject
-		.gitignore = .gitignore
-		version.json = version.json
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Webserver.API", "src\Webserver.API\Webserver.API.csproj", "{023E3E93-8E71-48BA-9616-CCEDF8A34415}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Webserver.Api.UnitTests", "tests\Webserver.API.UnitTests\Webserver.Api.UnitTests.csproj", "{F4F34F39-86B1-43D6-AD75-48ED8B45DFA8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{88538A94-22C2-485F-8D86-CA2F71ECE8AE}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		CONTRIBUTING.md = CONTRIBUTING.md
+		CONTRIBUTING.pdf = CONTRIBUTING.pdf
+		Directory.Build.props = Directory.Build.props
+		LICENSE.md = LICENSE.md
+		MAINTAINERS.md = MAINTAINERS.md
+		nuget.config = nuget.config
+		README.md = README.md
+		version.json = version.json
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Webserver.API/Webserver.API.csproj
+++ b/src/Webserver.API/Webserver.API.csproj
@@ -27,11 +27,13 @@
     </PackageReference>
     <PackageReference Include="MimeMapping" Version="1.0.1.37" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
   </ItemGroup>
-  <ItemGroup>
+
+	<ItemGroup>
     <None Include="..\..\docs\screens\product-simatic-s7-1500-256-256.png" Pack="true" PackagePath="\" />
   </ItemGroup>
+	
   <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
   </ItemGroup>

--- a/tests/Webserver.API.UnitTests/Webserver.Api.UnitTests.csproj
+++ b/tests/Webserver.API.UnitTests/Webserver.Api.UnitTests.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="3.2.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
@@ -22,7 +22,7 @@
 		</PackageReference>
 		<PackageReference Include="MimeMapping" Version="1.0.1.37" />
 		<PackageReference Include="nunit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
 	</ItemGroup>

--- a/tests/Webserver.API.UnitTests/Webserver.Api.UnitTests.csproj
+++ b/tests/Webserver.API.UnitTests/Webserver.Api.UnitTests.csproj
@@ -1,42 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Label="Globals">
-    <Platforms>x64;AnyCPU;x86</Platforms>
-  </PropertyGroup>
+	<PropertyGroup Label="Globals">
+		<Platforms>x64;AnyCPU;x86</Platforms>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFrameworks>net48;net6.0;net7.0;net8.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
-    <AssemblyName>Webserver.API.UnitTests</AssemblyName>
-    <RootNamespace>Webserver.API.UnitTests</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net48;net6.0;net7.0;net8.0</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<AssemblyName>Webserver.API.UnitTests</AssemblyName>
+		<RootNamespace>Webserver.API.UnitTests</RootNamespace>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="MimeMapping" Version="1.0.1.37" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="System.Web.Http.Common" Version="4.0.20126.16343" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="MimeMapping" Version="1.0.1.37" />
+		<PackageReference Include="nunit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+	</ItemGroup>
 
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Webserver.API\Webserver.API.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Webserver.API\Webserver.API.csproj" />
+	</ItemGroup>
 
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
changes:
- removed `Moq` from `Webserver.Api.UnitTests`
- removed `System.Web.Http.Common` from `Webserver.Api.UnitTests`
- updated `System.Net.Http` to be framework specific in `Webserver.API`

closes #48