### PR TITLE
Kirc max/dont log credentials

### DIFF
--- a/src/Webserver.API/Models/Responses/ApiErrorModel.cs
+++ b/src/Webserver.API/Models/Responses/ApiErrorModel.cs
@@ -25,6 +25,11 @@ namespace Siemens.Simatic.S7.Webserver.API.Models.Responses
         /// <param name="responseString"></param>
         public void ThrowAccordingException(string apiRequestString, string responseString)
         {
+            var loweredString = apiRequestString.ToLower();
+            if (loweredString.Contains("login") || loweredString.Contains("changepassword"))
+            {
+                apiRequestString = "not provided since it might contain credentials!";
+            }
             if (Error == null)
             {
                 throw new NullReferenceException($"Api Error with errorcode has been expected but error in model was null - response from server:{responseString}");

--- a/src/Webserver.API/Services/RequestHandling/ApiResponseChecker.cs
+++ b/src/Webserver.API/Services/RequestHandling/ApiResponseChecker.cs
@@ -6,6 +6,7 @@ using Siemens.Simatic.S7.Webserver.API.Exceptions;
 using Siemens.Simatic.S7.Webserver.API.Models.Responses;
 using System;
 using System.Net.Http;
+using System.Text;
 
 namespace Siemens.Simatic.S7.Webserver.API.Services.RequestHandling
 {
@@ -33,6 +34,9 @@ namespace Siemens.Simatic.S7.Webserver.API.Services.RequestHandling
                     case System.Net.HttpStatusCode.BadRequest:
                     case System.Net.HttpStatusCode.Forbidden:
                     default:
+                        StringBuilder errorMessage = new StringBuilder($"Request:");
+
+
                         var messageForException = $"Request:{apiRequestString.ToString() + Environment.NewLine}" +
                         $"has been responded with{((int)message.StatusCode).ToString() + message.ReasonPhrase}";
                         throw new InvalidHttpRequestException(messageForException);

--- a/src/Webserver.API/Services/RequestHandling/ApiResponseChecker.cs
+++ b/src/Webserver.API/Services/RequestHandling/ApiResponseChecker.cs
@@ -6,7 +6,6 @@ using Siemens.Simatic.S7.Webserver.API.Exceptions;
 using Siemens.Simatic.S7.Webserver.API.Models.Responses;
 using System;
 using System.Net.Http;
-using System.Text;
 
 namespace Siemens.Simatic.S7.Webserver.API.Services.RequestHandling
 {
@@ -34,9 +33,11 @@ namespace Siemens.Simatic.S7.Webserver.API.Services.RequestHandling
                     case System.Net.HttpStatusCode.BadRequest:
                     case System.Net.HttpStatusCode.Forbidden:
                     default:
-                        StringBuilder errorMessage = new StringBuilder($"Request:");
-
-
+                        var loweredString = apiRequestString.ToLower();
+                        if (loweredString.Contains("login") || loweredString.Contains("changepassword"))
+                        {
+                            apiRequestString = "not provided since it might contain credentials!";
+                        }
                         var messageForException = $"Request:{apiRequestString.ToString() + Environment.NewLine}" +
                         $"has been responded with{((int)message.StatusCode).ToString() + message.ReasonPhrase}";
                         throw new InvalidHttpRequestException(messageForException);

--- a/tests/Webserver.API.UnitTests/ApiRequestTests.cs
+++ b/tests/Webserver.API.UnitTests/ApiRequestTests.cs
@@ -56,7 +56,6 @@ namespace Webserver.API.UnitTests
                 }
                 Assert.Fail(assertString);
             }
-
         }
 
         /// <summary>
@@ -4248,5 +4247,102 @@ namespace Webserver.API.UnitTests
             TestHandler = new ApiHttpClientRequestHandler(client, ApiRequestFactory, ApiResponseChecker, ApiRequestSplitter);
             Assert.ThrowsAsync<ApiRequestTooLargeException>(async () => await TestHandler.ApiWebServerChangeResponseHeadersAsync("this is the header"));
         }
+
+        /// <summary>
+        /// We should not throw an exception containing the credentials that the user tried to login with (applications might log those to logfiles otherwise)
+        /// </summary>
+        [Test]
+        public void T090_ApiLogin_WithErrorMessage_DoesNotThrowIncludingApiRequestString()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            // Setup a respond for the user api (including a wildcard in the URL)
+            mockHttp.When(HttpMethod.Post, $"https://{Ip.ToString()}/api/jsonrpc")
+                .Respond("application/json", ResponseStrings.RequestTooLarge); // Respond with JSON
+            // Inject the handler or client into your application code
+            var client = new HttpClient(mockHttp);
+            client.BaseAddress = new Uri($"https://{Ip.ToString()}");
+            TestHandler = new ApiHttpClientRequestHandler(client, ApiRequestFactory, ApiResponseChecker, ApiRequestSplitter);
+            var username = "ThisIsTheUserNameToBeUsed";
+            var password = "ThisIsThePasswordToBeUsed";
+            var exc = Assert.ThrowsAsync<ApiRequestTooLargeException>(async () => await TestHandler.ApiLoginAsync(username, password));
+            Assert.Multiple(() =>
+            {
+                Assert.That(!exc.Message.Contains(username), "Username has been provided in the exception thrown!");
+                Assert.That(!exc.Message.Contains(password), "Password has been provided in the exception thrown!");
+                var currentExc = exc.InnerException;
+                while (currentExc != null)
+                {
+                    Assert.That(!currentExc.Message.Contains(username), "Username has been provided in the exception thrown!");
+                    Assert.That(!currentExc.Message.Contains(password), "Password has been provided in the exception thrown!");
+                    currentExc = currentExc.InnerException;
+                }
+            });
+        }
+
+        /// <summary>
+        /// We should not throw an exception containing the credentials that the user tried to login with (applications might log those to logfiles otherwise)
+        /// </summary>
+        [Test]
+        public void T091_ReLogin_WithErrorMessage_DoesNotThrowIncludingApiRequestString()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            // Setup a respond for the user api (including a wildcard in the URL)
+            mockHttp.When(HttpMethod.Post, $"https://{Ip.ToString()}/api/jsonrpc")
+                .Respond("application/json", ResponseStrings.RequestTooLarge); // Respond with JSON
+            // Inject the handler or client into your application code
+            var client = new HttpClient(mockHttp);
+            client.BaseAddress = new Uri($"https://{Ip.ToString()}");
+            TestHandler = new ApiHttpClientRequestHandler(client, ApiRequestFactory, ApiResponseChecker, ApiRequestSplitter);
+            var username = "ThisIsTheUserNameToBeUsed";
+            var password = "ThisIsThePasswordToBeUsed";
+            var exc = Assert.ThrowsAsync<ApiRequestTooLargeException>(async () => await TestHandler.ReLoginAsync(username, password));
+            Assert.Multiple(() =>
+            {
+                Assert.That(!exc.Message.Contains(username), "Username has been provided in the exception thrown!");
+                Assert.That(!exc.Message.Contains(password), "Password has been provided in the exception thrown!");
+                var currentExc = exc.InnerException;
+                while (currentExc != null)
+                {
+                    Assert.That(!currentExc.Message.Contains(username), "Username has been provided in the exception thrown!");
+                    Assert.That(!currentExc.Message.Contains(password), "Password has been provided in the exception thrown!");
+                    currentExc = currentExc.InnerException;
+                }
+            });
+        }
+
+        /// <summary>
+        /// We should not throw an exception containing the credentials that the user tried to login with (applications might log those to logfiles otherwise)
+        /// </summary>
+        [Test]
+        public void T092_ApiChangePassword_WithErrorMessage_DoesNotThrowIncludingApiRequestString()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            // Setup a respond for the user api (including a wildcard in the URL)
+            mockHttp.When(HttpMethod.Post, $"https://{Ip.ToString()}/api/jsonrpc")
+                .Respond("application/json", ResponseStrings.RequestTooLarge); // Respond with JSON
+            // Inject the handler or client into your application code
+            var client = new HttpClient(mockHttp);
+            client.BaseAddress = new Uri($"https://{Ip.ToString()}");
+            TestHandler = new ApiHttpClientRequestHandler(client, ApiRequestFactory, ApiResponseChecker, ApiRequestSplitter);
+            var username = "ThisIsTheUserNameToBeUsed";
+            var password = "ThisIsThePasswordToBeUsed";
+            var nextPassword = "ThisIsTheNewPasswordToBeApplied";
+            var exc = Assert.ThrowsAsync<ApiRequestTooLargeException>(async () => await TestHandler.ApiChangePasswordAsync(username, password, nextPassword));
+            Assert.Multiple(() =>
+            {
+                Assert.That(!exc.Message.Contains(username), "Username has been provided in the exception thrown!");
+                Assert.That(!exc.Message.Contains(password), "Password has been provided in the exception thrown!");
+                Assert.That(!exc.Message.Contains(nextPassword), "New Password has been provided in the exception thrown!");
+                var currentExc = exc.InnerException;
+                while (currentExc != null)
+                {
+                    Assert.That(!currentExc.Message.Contains(username), "Username has been provided in the exception thrown!");
+                    Assert.That(!currentExc.Message.Contains(password), "Password has been provided in the exception thrown!");
+                    Assert.That(!currentExc.Message.Contains(nextPassword), "New Password has been provided in the exception thrown!");
+                    currentExc = currentExc.InnerException;
+                }
+            });
+        }
+
     }
 }


### PR DESCRIPTION
Do not lead to possibly logging credentials by applications (do not 'ever' include credentials in exceptions thrown) with ApiRequestString